### PR TITLE
Update README with Rust backend build instructions and prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,51 @@ Visit the [release page](https://github.com/ZacharyL2/KeyEcho/releases) to downl
 
 ## 🧑‍💻 Development
 
+### Prerequisites
+
+#### Installing Rust and Cargo
+
+Cargo is the package manager for Rust. If you don't have it installed, follow these steps:
+
+1. Visit the [Rust installation page](https://www.rust-lang.org/tools/install).
+2. Follow the instructions for your operating system to install Rust and Cargo.
+3. Verify the installation by running `cargo --version` in your terminal.
+
+#### Installing pnpm
+
+pnpm is a fast, disk space-efficient package manager for JavaScript. To install:
+
+1. Visit the [pnpm installation page](https://pnpm.io/installation).
+2. Choose the installation method that suits your operating system.
+3. Verify the installation by running `pnpm --version` in your terminal.
+
+### Building and Running the Project
+
 ```bash
+# Clone the repository
 $ git clone git@github.com:ZacharyL2/KeyEcho.git
 $ cd KeyEcho
+
+# Install dependencies
 $ pnpm install
 
-# Dev
+# Build the Rust backend
+$ cd src-tauri
+$ cargo build
+$ cd ..
+
+# Run the development server
 $ pnpm dev
 
-# Build
+# Build for production
 $ pnpm build
+
+# To run the Rust backend separately:
+
+$ cd src-tauri
+$ cargo run
+
+# Then, from the root of the project, start the frontend:
+
+$ pnpm dev
 ```


### PR DESCRIPTION
Resolves #13 

This pull request updates the README to include:

1. Prerequisites section with installation instructions for Rust/Cargo and `pnpm`.
2. Updated build and run instructions that include the Rust backend build steps.
3. Separate instructions for running the Rust backend and frontend for development purposes.

These changes provide a more comprehensive guide for developers looking to contribute to or run the KeyEcho project, especially focusing on the Rust backend components.

The updates maintain the existing structure and content of the README while adding the necessary information for working with both the frontend and backend of the project.